### PR TITLE
Prevent node-addon-api from being called during installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
+#### 2.0.1 (2025-01-12)
+
+##### Fixes
+
+*  Prevent node-addon-api from being called during installation ([856468f](https://github.com/primno/dpapi/commit/856468f436d3c60e79353993fb76f0dc039775ee))
+
 #### 2.0.0 (2025-01-01)
 
 ##### Features
 
 *  Add support for arm64 ([03707dd](https://github.com/primno/dpapi/commit/03707dd007a60f4f4abfc423f781e503edbcc92e))
 *  Add platform support flag ([755cb93](https://github.com/primno/dpapi/commit/755cb9326c8254861859aa0219d49fa06aa421d5))
-
 
 #### 1.1.1 (2023-03-25)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@primno/dpapi",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@primno/dpapi",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primno/dpapi",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Pre-built version of DPAPI (Data Protection API of Windows). Encrypt and decrypt data.",
   "main": "dist/index.js",
   "files": [
@@ -12,7 +12,7 @@
   ],
   "gypfile": true,
   "scripts": {
-    "install": "node-gyp-build",
+    "install": "exit 0",
     "build": "tsc && npm run prebuild",
     "rebuild": "npm run install --build-from-source",
     "prebuild": "prebuildify --napi --strip --arch x64 && prebuildify --napi --strip --arch arm64",


### PR DESCRIPTION
Prevent node-addon-api from being called during installation.

Allows the package to be installed on Linux and macOS.